### PR TITLE
Start using GiellaLTGramTools

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -130,14 +130,11 @@ nobase_dist_pkgdata_SCRIPTS = \
    scripts/iso639-to-name.sh \
    scripts/iso-639-3.txt \
    scripts/lookup2cg \
-   scripts/make_grammarchecker_zip.py \
    scripts/make-hfstspeller-version-easter-egg.sh \
    scripts/make-lemmacount.json.sh \
    scripts/make-maturity.json.sh \
    scripts/merge-templates.sh \
    scripts/morph-test.py \
-   scripts/gramcheck-test.py \
-   scripts/gramcheck_comparator.py \
    scripts/new-language.sh \
    scripts/patgen.exp \
    scripts/predict.py \

--- a/am-shared/tools-grammarcheckers-dir-include.am
+++ b/am-shared/tools-grammarcheckers-dir-include.am
@@ -149,7 +149,7 @@ else !CAN_PIP
 	echo lxml and pip is missing so this may fail...:
 endif 
 endif
-	$(AM_V_GEN)$(GTCORE)/scripts/make_grammarchecker_zip.py pipespec.xml $@
+	make_grammarchecker_zip pipespec.xml $@
 
 # Additional developer tools:
 dev: modes/$(GTLANG)gram.mode schemas.xml

--- a/am-shared/tools-grammarcheckers-tests-dir-include.am
+++ b/am-shared/tools-grammarcheckers-tests-dir-include.am
@@ -7,6 +7,6 @@
 if WANT_GRAMCHECK
 
 # Default variable for all languages
-TESTS_ENVIRONMENT = "$(GIELLA_CORE)/scripts/gramcheck-test.py" -q -s ../$(GTLANG2).zcheck 2>/dev/null
+TESTS_ENVIRONMENT = gramcheck-yaml -q -s ../$(GTLANG2).zcheck 2>/dev/null
 
 endif # WANT_GRAMCHECK


### PR DESCRIPTION
GiellaLTGramTools gather the scripts gramcheck-test.py, gramcheck_comparator.py and make_grammarchecker_zip.py into a separate, pipx installable repo.
