### PR TITLE
Improve missing.py escaping

### DIFF
--- a/scripts/missing.py
+++ b/scripts/missing.py
@@ -41,10 +41,16 @@ class LexcEntry:
     def __str__(self) -> str:
         tags = "+".join(self.tags)
         return (
-            f"{self.stem.replace(' ', '% ')}{'+' if tags else ''}{tags}:"
-            f"{self.lower.replace(' ', '% ')} {self.contlex} ; "
+            f"{self.escape_lexc(self.stem)}{'+' if tags else ''}{tags}:"
+            f"{self.escape_lexc(self.lower)} {self.contlex} ; "
             f"! {self.filename} {self.parent_lexicon}"
         )
+
+    def escape_lexc(self, s):
+        """
+        Escape spaces and lexc special characters !, 0 and %
+        """
+        return re.sub(r"([ 0!%])", r"%\1", s)
 
 
 LEXC_LINE_RE = re.compile(

--- a/scripts/missing.py
+++ b/scripts/missing.py
@@ -48,9 +48,9 @@ class LexcEntry:
 
     def escape_lexc(self, s):
         """
-        Escape spaces and lexc special characters !, 0 and %
+        Escape spaces and lexc special character 0
         """
-        return re.sub(r"([ 0!%])", r"%\1", s)
+        return re.sub(r"([ 0])", r"%\1", s)
 
 
 LEXC_LINE_RE = re.compile(


### PR DESCRIPTION
Zeros might be found in missing lists and should be escaped the same way spaces are escaped. In theory there are more special lexc characters, but I refrained from including these, as they are much less likely to appear in missing lists and might cause other, unforeseen consequences. The stems already e.g. include percent signs and pound signs, which should not be escaped on the lower side

I have tested the script with a short input file:
```
1800-viessu
Buorre Báiki
```
This worked as intended:
```
Buorre% Báiki+A+CmpN/SgN+CmpN/PlG+Sem/Hum:Buorre% Bájºki LAIKI ; ! adjectives.lexc AdjectiveNoPx Inputfile: $GTLANGS/giella-core/input.txt
Buorre% Báiki:Buorre% Bájºki MARJA-I-plc ; ! sme-propernouns.lexc ProperNoun-sme Inputfile: $GTLANGS/giella-core/input.txt
Buorre% Báiki+N+Prop+Sg+Nom:Buorre% Báik # ; ! sma-sme-propernouns.lexc ProperNoun-sma Inputfile: $GTLANGS/giella-core/input.txt
Buorre% Báiki+MWE+CmpNP/First:Buorre% Bájºki MARJA-IU_MWE-plc ; ! sme-propernouns.lexc ProperNoun-sme Inputfile: $GTLANGS/giella-core/input.txt
Buorre% Báiki:Buorre% Bájºki MARJA-I-org ; ! sme-propernouns.lexc ProperNoun-sme Inputfile: $GTLANGS/giella-core/input.txt
Buorre% Báiki+N+CmpN/SgN+CmpN/SgG+CmpN/PlG+CmpNP/First+Sem/Plc:Buorre% Bájºki ALBMI ; ! nouns.lexc HyphNouns Inputfile: $GTLANGS/giella-core/input.txt
Buorre% Báiki+N+Sem/Build-room:Buorre% Báikás DER-SAS ; ! nouns.lexc SASCont Inputfile: $GTLANGS/giella-core/input.txt
Buorre% Báiki+N+CmpN/SgN+CmpN/SgG+CmpN/PlG+Sem/Plc:Buorre% Bájºki ALBMI ; ! nouns.lexc NounPx Inputfile: $GTLANGS/giella-core/input.txt
Buorre% Báiki+N+Sem/Plc+Ess+Err/Orth:Buorre% Báikkin K ; ! nouns.lexc NounPx Inputfile: $GTLANGS/giella-core/input.txt
Buorre% Báiki+N+Sem/Plc+Err/Lex+Use/LIA:Buorre% Bájºki ALBMI ; ! nouns.lexc NounNoPx Inputfile: $GTLANGS/giella-core/input.txt
Buorre% Báiki+N+Sem/Dummytag:Buorre% Bájºki GOAHTI-I ; ! nouns.lexc NounPx Inputfile: $GTLANGS/giella-core/input.txt



!!! Compounds and derivations only !!!
18%0%0-viessu+N+CmpN/SgN+CmpN/SgG+CmpN/PlG+Sem/Build:18%0%0-#viessu GOAHTI-U ; ! nouns.lexc NounPx Inputfile: $GTLANGS/giella-core/input.txt
```

I also tested the updated script on a missing list of 1000 words and did not notice any incorrect entries.

The commit fixes #82 